### PR TITLE
correct git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Example Qt app for the QtFirebase project
     Clone into the "extensions" folder or into other folder of your choice
     ```
     cd /path/to/projects/QtFirebaseExample/extensions
-    git clone git@github.com:Larpon/QtFirebase.git
+    git clone https://github.com/Larpon/QtFirebase.git
     ```
 
 2. Download and unzip the latest 2.x Firebase C++ SDK from Google.


### PR DESCRIPTION
else we obtain:
```
git clone git@github.com:Larpon/QtFirebase.git
Cloning into 'QtFirebase'...
The authenticity of host 'github.com (192.30.253.113)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'github.com,192.30.253.113' (RSA) to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```